### PR TITLE
Add title to the dumper, so you can more easily spot it in Unlaunch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.nds
+*.elf
+arm7/build
+arm9/build

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ export TOPDIR	:=	$(CURDIR)
 NITRO_FILES	:=
 
 # These set the information text in the nds file
-#GAME_TITLE     := My Wonderful Homebrew
-#GAME_SUBTITLE1 := built with devkitARM
-#GAME_SUBTITLE2 := http://devitpro.org
+GAME_TITLE     := dsibiosdumper
+GAME_SUBTITLE1 := A tool for dumping the DSi BIOS
+GAME_SUBTITLE2 := For use with melonDS or no$$gba
 
 include $(DEVKITARM)/ds_rules
 

--- a/arm9/source/template.c
+++ b/arm9/source/template.c
@@ -7,6 +7,7 @@
 #include <nds.h>
 #include <fat.h>
 #include <stdio.h>
+#include <string.h>
 
 u32 getCP15Ctrl();
 void disableMPU();
@@ -16,8 +17,6 @@ u8 workBuffer[0x10000];
 //---------------------------------------------------------------------------------
 int main(void) {
 //---------------------------------------------------------------------------------
-	touchPosition touch;
-	
 	DC_FlushAll();
 	disableMPU();
 


### PR DESCRIPTION
Without adding a title, it can be confusing to try and find it in the Unlaunch Filemenu, as it is just a blank line.